### PR TITLE
Made World responsible for tileweight instead of chunk class

### DIFF
--- a/Scripts/RTS/Atlas.cs
+++ b/Scripts/RTS/Atlas.cs
@@ -1,0 +1,16 @@
+﻿namespace RTS;
+
+public class Atlas
+{
+    public TileMap TileMap { get; }
+    public FastNoiseLite FNL { get; }
+    public Dictionary<string, AtlasWeight> TileData { get; }
+
+    public Atlas(TileMap tileMap, FastNoiseLite fnl, Dictionary<string, AtlasWeight> tileData)
+    {
+        this.TileMap = tileMap;
+        this.FNL = fnl;
+        this.TileData = tileData;
+        this.TileData.Add("empty", new AtlasWeight(Vector2I.Zero, 0));
+    }
+}

--- a/Scripts/RTS/Atlas.cs
+++ b/Scripts/RTS/Atlas.cs
@@ -6,11 +6,35 @@ public class Atlas
     public FastNoiseLite FNL { get; }
     public Dictionary<string, AtlasWeight> TileData { get; }
 
-    public Atlas(TileMap tileMap, FastNoiseLite fnl, Dictionary<string, AtlasWeight> tileData)
+    public Atlas(TileMap tileMap, FastNoiseLite fnl, Dictionary<string, AtlasWeight> tileData, float emptyWeight = 0f)
     {
+        tileData.Add("empty", new AtlasWeight(Vector2I.Zero, emptyWeight));
+
         this.TileMap = tileMap;
         this.FNL = fnl;
-        this.TileData = tileData;
-        this.TileData.Add("empty", new AtlasWeight(Vector2I.Zero, 0));
+        this.TileData = TransformWeightsToRange(tileData);
+    }
+
+    public Dictionary<string, AtlasWeight> TransformWeightsToRange(Dictionary<string, AtlasWeight> dictionary)
+    {
+        Dictionary<string, AtlasWeight> result = new();
+
+        float totalWeight = 0f;
+        foreach (var pair in dictionary) totalWeight += pair.Value.Weight;
+    
+        // Set current value to the lowerbound of the range
+        float currentValue = -1;
+
+        // Transform the weights to be between [-1, 1], as per FastNoiseLite range
+        foreach (var pair in dictionary)
+        {
+            AtlasWeight atlasWeight = pair.Value;
+            float weight = atlasWeight.Weight;
+    
+            currentValue += weight / totalWeight * 2;
+    
+            result.Add(pair.Key, new AtlasWeight(atlasWeight.TilePosition, currentValue));
+        }
+        return result;
     }
 }

--- a/Scripts/RTS/AtlasWeight.cs
+++ b/Scripts/RTS/AtlasWeight.cs
@@ -2,11 +2,12 @@ namespace RTS;
 
 public class AtlasWeight
 {
+    public Vector2I TilePosition;
+    public float Weight;
+
     public AtlasWeight(Vector2I tilePosition, float weight)
     {
         this.TilePosition = tilePosition;
         this.Weight = weight;
     }
-    public Vector2I TilePosition;
-    public float Weight;
 }

--- a/Scripts/RTS/AtlasWeight.cs
+++ b/Scripts/RTS/AtlasWeight.cs
@@ -1,0 +1,13 @@
+namespace RTS;
+using Godot;
+
+public class AtlasWeight
+{
+    public AtlasWeight(Vector2I tilePosition, float weight)
+    {
+        this.TilePosition = tilePosition;
+        this.Weight = weight;
+    }
+    public Vector2I TilePosition;
+    public float Weight;
+}

--- a/Scripts/RTS/AtlasWeight.cs
+++ b/Scripts/RTS/AtlasWeight.cs
@@ -2,8 +2,8 @@ namespace RTS;
 
 public class AtlasWeight
 {
-    public Vector2I TilePosition;
-    public float Weight;
+    public Vector2I TilePosition { get; }
+    public float Weight { get; }
 
     public AtlasWeight(Vector2I tilePosition, float weight)
     {

--- a/Scripts/RTS/AtlasWeight.cs
+++ b/Scripts/RTS/AtlasWeight.cs
@@ -1,5 +1,4 @@
 namespace RTS;
-using Godot;
 
 public class AtlasWeight
 {

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -23,7 +23,7 @@ public class Chunk
                 string type = "";
                 var currentNoise = noise.GetNoise2D(globalX, globalY);
                 var name = ((string) (this.tileMap.Name)).ToLower();
-                var limitedAtlas = World.Atlas.Where(pair => pair.Key.Contains(name)).ToDictionary(pair => pair.Key, pair => pair.Value);
+                var limitedAtlas = World.Atlas.Where(pair => pair.Key.ToLower().Contains(name)).ToDictionary(pair => pair.Key, pair => pair.Value);
 
                 foreach (var atlasValue in limitedAtlas)
                 {

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -37,9 +37,8 @@ public class Chunk
 
                 if (type != string.Empty) 
                     SetCell(globalX, globalY, World.Atlas[type].TilePosition);
-
-                // GD.PrintErr not printing to console in editor?
-                else GD.PrintErr("No type found for noise: " + currentNoise);
+                else 
+                    GD.Print("No type found for noise: " + currentNoise);
             }
         }
     }

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -1,4 +1,6 @@
-﻿namespace RTS;
+﻿using Godot;
+
+namespace RTS;
 
 public class Chunk
 {
@@ -15,29 +17,30 @@ public class Chunk
     void GenerateChunk(int chunkX, int chunkY, TileMap tileMap, Noise noise)
     {
         for (int x = 0; x < World.ChunkSize; x++)
-        {
             for (int y = 0; y < World.ChunkSize; y++)
+                GenerateTile(chunkX, chunkY, x, y, tileMap, noise);
+    }
+
+    void GenerateTile(int chunkX, int chunkY, int x, int y, TileMap tileMap, Noise noise)
+    {
+        var globalX = (chunkX * World.ChunkSize) + x;
+        var globalY = (chunkY * World.ChunkSize) + y;
+
+        string type = "";
+        var currentNoise = noise.GetNoise2D(globalX, globalY);
+        var name = ((string) (this.tileMap.Name)).ToLower();
+        var limitedAtlas = World.Atlas.Where(pair => pair.Key.ToLower().Contains(name)).ToDictionary(pair => pair.Key, pair => pair.Value);
+
+        foreach (var atlasValue in limitedAtlas)
+        {
+            if (currentNoise < atlasValue.Value.Weight)
             {
-                var globalX = (chunkX * World.ChunkSize) + x;
-                var globalY = (chunkY * World.ChunkSize) + y;
-
-                string type = "";
-                var currentNoise = noise.GetNoise2D(globalX, globalY);
-                var name = ((string) (this.tileMap.Name)).ToLower();
-                var limitedAtlas = World.Atlas.Where(pair => pair.Key.ToLower().Contains(name)).ToDictionary(pair => pair.Key, pair => pair.Value);
-
-                foreach (var atlasValue in limitedAtlas)
-                {
-                    if (currentNoise < atlasValue.Value.Weight)
-                    {
-                        type = atlasValue.Key;
-                        break;
-                    }
-                }
-
-                SetCell(globalX, globalY, World.Atlas[type].TilePosition);
+                type = atlasValue.Key;
+                break;
             }
         }
+
+        SetCell(globalX, globalY, World.Atlas[type].TilePosition);
     }
 
     void SetCell(int x, int y, Vector2I type) =>

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -7,7 +7,9 @@ public class Chunk
     public Chunk(int chunkX, int chunkY, TileMap tileMap, Noise noise, bool generate = true)
     {
         this.tileMap = tileMap;
-        if(generate) this.GenerateWorld(chunkX, chunkY, tileMap, noise);
+
+        if (generate) 
+            this.GenerateWorld(chunkX, chunkY, tileMap, noise);
     }
 
     void GenerateWorld(int chunkX, int chunkY, TileMap tileMap, Noise noise)
@@ -33,7 +35,9 @@ public class Chunk
                     }
                 }
 
-                if(type != "") SetCell(globalX, globalY, World.Atlas[type].TilePosition);
+                if (type != string.Empty) 
+                    SetCell(globalX, globalY, World.Atlas[type].TilePosition);
+
                 // GD.PrintErr not printing to console in editor?
                 else GD.PrintErr("No type found for noise: " + currentNoise);
             }
@@ -42,5 +46,4 @@ public class Chunk
 
     void SetCell(int x, int y, Vector2I type) =>
         tileMap.SetCell(0, new Vector2I(x, y), 0, type);
-
 }

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -38,7 +38,9 @@ public class Chunk
             }
         }
 
-        SetCell(globalX, globalY, World.Atlas[type].TilePosition);
+        SetCell(globalX, globalY, !string.IsNullOrWhiteSpace(type) ?
+            World.AtlasGrass[type].TilePosition :
+            World.AtlasGrass.First().Value.TilePosition);
     }
 
     void SetCell(int x, int y, Vector2I type) =>

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -1,35 +1,29 @@
-﻿using Godot;
-
-namespace RTS;
+﻿namespace RTS;
 
 public class Chunk
 {
-    TileMap tileMap;
-
-    public Chunk(int chunkX, int chunkY, TileMap tileMap, Noise noise, bool generate = true)
+    public Chunk(int chunkX, int chunkY)
     {
-        this.tileMap = tileMap;
-
-        if (generate) 
-            this.GenerateChunk(chunkX, chunkY, tileMap, noise);
+        this.GenerateChunk(chunkX, chunkY);
     }
 
-    void GenerateChunk(int chunkX, int chunkY, TileMap tileMap, Noise noise)
+    void GenerateChunk(int chunkX, int chunkY)
     {
-        for (int x = 0; x < World.ChunkSize; x++)
-            for (int y = 0; y < World.ChunkSize; y++)
-                GenerateTile(chunkX, chunkY, x, y, tileMap, noise);
+        foreach (var atlas in World.Atlases)
+            for (int x = 0; x < World.ChunkSize; x++)
+                for (int y = 0; y < World.ChunkSize; y++)
+                    GenerateTile(chunkX, chunkY, x, y, atlas);
     }
 
-    void GenerateTile(int chunkX, int chunkY, int x, int y, TileMap tileMap, Noise noise)
+    void GenerateTile(int chunkX, int chunkY, int x, int y, Atlas atlas)
     {
         var globalX = (chunkX * World.ChunkSize) + x;
         var globalY = (chunkY * World.ChunkSize) + y;
 
         string type = "";
-        var currentNoise = noise.GetNoise2D(globalX, globalY);
+        var currentNoise = atlas.FNL.GetNoise2D(globalX, globalY);
 
-        foreach (var atlasValue in World.AtlasGrass)
+        foreach (var atlasValue in atlas.TileData)
         {
             if (currentNoise < atlasValue.Value.Weight)
             {
@@ -38,13 +32,17 @@ public class Chunk
             }
         }
 
-        SetCell(globalX, globalY, type, !string.IsNullOrWhiteSpace(type) ?
-            World.AtlasGrass[type].TilePosition :
-            World.AtlasGrass.First().Value.TilePosition);
+        SetCell(
+            atlas.TileMap, 
+            type,
+            globalX, 
+            globalY, 
+            atlas.TileData[type].TilePosition);
     }
 
-    void SetCell(int x, int y, string typeName, Vector2I type)
+    void SetCell(TileMap tileMap, string typeName, int x, int y, Vector2I atlasPos)
     {
-        if (typeName != "empty")  tileMap.SetCell(0, new Vector2I(x, y), 0, type);
+        if (typeName != "empty")
+            tileMap.SetCell(0, new Vector2I(x, y), 0, atlasPos);
     }
 }

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -9,10 +9,10 @@ public class Chunk
         this.tileMap = tileMap;
 
         if (generate) 
-            this.GenerateWorld(chunkX, chunkY, tileMap, noise);
+            this.GenerateChunk(chunkX, chunkY, tileMap, noise);
     }
 
-    void GenerateWorld(int chunkX, int chunkY, TileMap tileMap, Noise noise)
+    void GenerateChunk(int chunkX, int chunkY, TileMap tileMap, Noise noise)
     {
         for (int x = 0; x < World.ChunkSize; x++)
         {

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -1,5 +1,4 @@
 ﻿namespace RTS;
-using System.Collections.Generic;
 
 public class Chunk
 {

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -28,10 +28,8 @@ public class Chunk
 
         string type = "";
         var currentNoise = noise.GetNoise2D(globalX, globalY);
-        var name = ((string) (this.tileMap.Name)).ToLower();
-        var limitedAtlas = World.Atlas.Where(pair => pair.Key.ToLower().Contains(name)).ToDictionary(pair => pair.Key, pair => pair.Value);
 
-        foreach (var atlasValue in limitedAtlas)
+        foreach (var atlasValue in World.AtlasGrass)
         {
             if (currentNoise < atlasValue.Value.Weight)
             {

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -35,10 +35,7 @@ public class Chunk
                     }
                 }
 
-                if (type != string.Empty) 
-                    SetCell(globalX, globalY, World.Atlas[type].TilePosition);
-                else 
-                    GD.Print("No type found for noise: " + currentNoise);
+                SetCell(globalX, globalY, World.Atlas[type].TilePosition);
             }
         }
     }

--- a/Scripts/RTS/Chunk.cs
+++ b/Scripts/RTS/Chunk.cs
@@ -38,11 +38,13 @@ public class Chunk
             }
         }
 
-        SetCell(globalX, globalY, !string.IsNullOrWhiteSpace(type) ?
+        SetCell(globalX, globalY, type, !string.IsNullOrWhiteSpace(type) ?
             World.AtlasGrass[type].TilePosition :
             World.AtlasGrass.First().Value.TilePosition);
     }
 
-    void SetCell(int x, int y, Vector2I type) =>
-        tileMap.SetCell(0, new Vector2I(x, y), 0, type);
+    void SetCell(int x, int y, string typeName, Vector2I type)
+    {
+        if (typeName != "empty")  tileMap.SetCell(0, new Vector2I(x, y), 0, type);
+    }
 }

--- a/Scripts/RTS/Player.cs
+++ b/Scripts/RTS/Player.cs
@@ -7,8 +7,23 @@ public partial class Player : Entity
 
     int prevChunkX, prevChunkY;
     int chunkSpawnRadius = 3;
+    GTimer timer;
+
+    protected override void Init()
+    {
+        timer = new(this, 2000) { Loop = true };
+        timer.Finished += SpawnNewChunks;
+        timer.Start();
+    }
 
     protected override void Update()
+    {
+        
+    }
+
+    protected override State InitialState() => Move();
+
+    void SpawnNewChunks()
     {
         var pixelChunkSize = World.ChunkSize * World.TileSize;
 
@@ -44,8 +59,6 @@ public partial class Player : Entity
         prevChunkX = chunkX;
         prevChunkY = chunkY;
     }
-
-    protected override State InitialState() => Move();
 
     State Move()
     {

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -5,50 +5,50 @@ namespace RTS;
 
 public partial class World : Node
 {
-    public static World Instance { get; private set; }
-    public static Dictionary<string, Vector2I> Atlas { get; } = new()
-    {
-        { "grass_1", new Vector2I(3, 1) },
-        { "grass_2", new Vector2I(0, 8) },
-        { "tree_1", new Vector2I(6, 4) }
-    };
+	public static World Instance { get; private set; }
+	public static Dictionary<string, AtlasWeight> Atlas { get; } = new()
+	{
+		{ "grass_1", new AtlasWeight(new Vector2I(3, 1), 	0.3f) },
+		{ "grass_2", new AtlasWeight(new Vector2I(0, 8), 	1f) },
+		{ "tree_1",  new AtlasWeight(new Vector2I(6, 4), 	0.1f) }
+	};
 
-    public static int ChunkSize { get; } = 10;
-    public static int TileSize { get; } = 16;
-    public static int SpawnRadius { get; } = 3;
-    public static Dictionary<Vector2I, bool> ChunkGenerated { get; } = new();
+	public static int ChunkSize { get; } = 10;
+	public static int TileSize { get; } = 16;
+	public static int SpawnRadius { get; } = 3;
+	public static Dictionary<Vector2I, bool> ChunkGenerated { get; } = new();
 
-    [Export] public TileMap Grass { get; set; }
-    [Export] public TileMap Trees { get; set; }
+	[Export] public TileMap Grass { get; set; }
+	[Export] public TileMap Trees { get; set; }
 
-    Noise noise;
+	Noise noise;
 
-    public override void _Ready()
-    {
-        Instance = this;
+	public override void _Ready()
+	{
+		Instance = this;
 
-        noise = new FastNoiseLite
-        {
-            Frequency = 0.1f
-        };
+		noise = new FastNoiseLite
+		{
+			Frequency = 0.1f
+		};
 
-        GenerateSpawn();
-    }
+		GenerateSpawn();
+	}
 
-    public void GenerateChunk(int x, int y)
-    {
-        World.ChunkGenerated[new Vector2I(x, y)] = true;
-        new Chunk(x, y, Grass, noise);
-    }
+	public void GenerateChunk(int x, int y)
+	{
+		World.ChunkGenerated[new Vector2I(x, y)] = true;
+		new Chunk(x, y, Grass, noise);
+	}
 
-    void GenerateSpawn()
-    {
-        for (int x = -SpawnRadius; x <= SpawnRadius; x++)
-        {
-            for (int y = -SpawnRadius; y <= SpawnRadius; y++)
-            {
-                new Chunk(x, y, Grass, noise);
-            }
-        }
-    }
+	void GenerateSpawn()
+	{
+		for (int x = -SpawnRadius; x <= SpawnRadius; x++)
+		{
+			for (int y = -SpawnRadius; y <= SpawnRadius; y++)
+			{
+				new Chunk(x, y, Grass, noise);
+			}
+		}
+	}
 }

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -5,9 +5,9 @@ public partial class World : Node
 	public static World Instance { get; private set; }
 	public static Dictionary<string, AtlasWeight> Atlas { get; } = new()
 	{
-		{ "grass_1", new AtlasWeight(new Vector2I(3, 1), 	0.3f) },
-		{ "grass_2", new AtlasWeight(new Vector2I(0, 8), 	1f) },
-		{ "tree_1",  new AtlasWeight(new Vector2I(6, 4), 	0.1f) }
+		{ "grass_1", new AtlasWeight(new Vector2I(3, 1), 0.3f) },
+		{ "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) },
+		{ "tree_1",  new AtlasWeight(new Vector2I(6, 4), 0.1f) }
 	};
 
 	public static int ChunkSize { get; } = 10;

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -3,16 +3,16 @@ namespace RTS;
 public partial class World : Node
 {
     public static World Instance { get; private set; }
-    public static Dictionary<string, AtlasWeight> AtlasGrass { get; } = new()
+    public static Dictionary<string, AtlasWeight> AtlasGrass { get; } =  SortAtlasByWeight(new() 
     {
         { "grass_1", new AtlasWeight(new Vector2I(3, 1), 0.3f) },
         { "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) }
-    };
+    });
 
-    public static Dictionary<string, AtlasWeight> AtlasTrees { get; } = new()
+    public static Dictionary<string, AtlasWeight> AtlasTrees { get; } = SortAtlasByWeight(new()
     {
         { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 0.1f) }
-    };
+    });
 
     public static int ChunkSize { get; } = 10;
     public static int TileSize { get; } = 16;
@@ -52,4 +52,8 @@ public partial class World : Node
             }
         }
     }
+
+    static Dictionary<string, AtlasWeight>  SortAtlasByWeight(Dictionary<string, AtlasWeight> Atlas) =>
+        Atlas.OrderBy(pair => pair.Value.Weight).ToDictionary(pair => pair.Key, pair => pair.Value);
+
 }

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -1,6 +1,3 @@
-using Godot;
-using System.Drawing;
-
 namespace RTS;
 
 public partial class World : Node

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -2,50 +2,50 @@ namespace RTS;
 
 public partial class World : Node
 {
-	public static World Instance { get; private set; }
-	public static Dictionary<string, AtlasWeight> Atlas { get; } = new()
-	{
-		{ "grass_1", new AtlasWeight(new Vector2I(3, 1), 0.3f) },
-		{ "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) },
-		{ "tree_1",  new AtlasWeight(new Vector2I(6, 4), 0.1f) }
-	};
+    public static World Instance { get; private set; }
+    public static Dictionary<string, AtlasWeight> Atlas { get; } = new()
+    {
+        { "grass_1", new AtlasWeight(new Vector2I(3, 1), 0.3f) },
+        { "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) },
+        { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 0.1f) }
+    };
 
-	public static int ChunkSize { get; } = 10;
-	public static int TileSize { get; } = 16;
-	public static int SpawnRadius { get; } = 3;
-	public static Dictionary<Vector2I, bool> ChunkGenerated { get; } = new();
+    public static int ChunkSize { get; } = 10;
+    public static int TileSize { get; } = 16;
+    public static int SpawnRadius { get; } = 3;
+    public static Dictionary<Vector2I, bool> ChunkGenerated { get; } = new();
 
-	[Export] public TileMap Grass { get; set; }
-	[Export] public TileMap Trees { get; set; }
+    [Export] public TileMap Grass { get; set; }
+    [Export] public TileMap Trees { get; set; }
 
-	Noise noise;
+    Noise noise;
 
-	public override void _Ready()
-	{
-		Instance = this;
+    public override void _Ready()
+    {
+        Instance = this;
 
-		noise = new FastNoiseLite
-		{
-			Frequency = 0.1f
-		};
+        noise = new FastNoiseLite
+        {
+            Frequency = 0.1f
+        };
 
-		GenerateSpawn();
-	}
+        GenerateSpawn();
+    }
 
-	public void GenerateChunk(int x, int y)
-	{
-		World.ChunkGenerated[new Vector2I(x, y)] = true;
-		new Chunk(x, y, Grass, noise);
-	}
+    public void GenerateChunk(int x, int y)
+    {
+        World.ChunkGenerated[new Vector2I(x, y)] = true;
+        new Chunk(x, y, Grass, noise);
+    }
 
-	void GenerateSpawn()
-	{
-		for (int x = -SpawnRadius; x <= SpawnRadius; x++)
-		{
-			for (int y = -SpawnRadius; y <= SpawnRadius; y++)
-			{
-				new Chunk(x, y, Grass, noise);
-			}
-		}
-	}
+    void GenerateSpawn()
+    {
+        for (int x = -SpawnRadius; x <= SpawnRadius; x++)
+        {
+            for (int y = -SpawnRadius; y <= SpawnRadius; y++)
+            {
+                new Chunk(x, y, Grass, noise);
+            }
+        }
+    }
 }

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -3,15 +3,15 @@ namespace RTS;
 public partial class World : Node
 {
     public static World Instance { get; private set; }
-    public static Dictionary<string, AtlasWeight> AtlasGrass { get; } =  SortAtlasByWeight(new() 
+    public static Dictionary<string, AtlasWeight> AtlasGrass { get; } =  TransformWeightsToRange(new() 
     {
-        { "grass_1", new AtlasWeight(new Vector2I(3, 1), 0.3f) },
-        { "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) }
+        { "grass_1", new AtlasWeight(new Vector2I(3, 1), 10f) },
+        { "grass_2", new AtlasWeight(new Vector2I(0, 8), 10f) }
     });
 
-    public static Dictionary<string, AtlasWeight> AtlasTrees { get; } = SortAtlasByWeight(new()
+    public static Dictionary<string, AtlasWeight> AtlasTrees { get; } = TransformWeightsToRange(new()
     {
-        { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 0.1f) }
+        { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 10f) }
     });
 
     public static int ChunkSize { get; } = 10;
@@ -53,7 +53,29 @@ public partial class World : Node
         }
     }
 
-    static Dictionary<string, AtlasWeight>  SortAtlasByWeight(Dictionary<string, AtlasWeight> Atlas) =>
-        Atlas.OrderBy(pair => pair.Value.Weight).ToDictionary(pair => pair.Key, pair => pair.Value);
+    public static Dictionary<string, AtlasWeight> TransformWeightsToRange(Dictionary<string, AtlasWeight> dictionary)
+    {
+        
+        Dictionary<string, AtlasWeight> result = new();
+        float totalWeight = 0f;
+    
+        // Find the minimum and maximum weights in the dictionary
+        foreach (var pair in dictionary) totalWeight += pair.Value.Weight;
+    
+        float currentValue = -1;
+        // Transform the weights to be between [-1, 1]
+        foreach (var pair in dictionary)
+        {
+            AtlasWeight atlasWeight = pair.Value;
+            float weight = atlasWeight.Weight;
+    
+            // Apply the transformation formula
+            currentValue += weight / totalWeight * 2;
+    
+            // Update the weight value in the AtlasWeight object
+            result.Add(pair.Key, new AtlasWeight(atlasWeight.TilePosition, currentValue));
+        }
+        return result;
+    }
 
 }

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -5,12 +5,14 @@ public partial class World : Node
     public static World Instance { get; private set; }
     public static Dictionary<string, AtlasWeight> AtlasGrass { get; } =  TransformWeightsToRange(new() 
     {
-        { "grass_1", new AtlasWeight(new Vector2I(3, 1), 10f) },
+        { "empty",   new AtlasWeight(new Vector2I(0, 0), 0f) },
+        { "grass_1", new AtlasWeight(new Vector2I(3, 1), 20f) },
         { "grass_2", new AtlasWeight(new Vector2I(0, 8), 10f) }
     });
 
     public static Dictionary<string, AtlasWeight> AtlasTrees { get; } = TransformWeightsToRange(new()
     {
+        { "empty",   new AtlasWeight(new Vector2I(0, 0), 0f) },
         { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 10f) }
     });
 
@@ -69,6 +71,7 @@ public partial class World : Node
             AtlasWeight atlasWeight = pair.Value;
             float weight = atlasWeight.Weight;
     
+            // We're going from a range of [0, 1] to [-1, 1], so multiply by 2
             currentValue += weight / totalWeight * 2;
     
             result.Add(pair.Key, new AtlasWeight(atlasWeight.TilePosition, currentValue));

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -15,16 +15,16 @@ public partial class World : Node
     [Export] public TileMap Grass { get; set; }
     [Export] public TileMap Trees { get; set; }
 
-    Dictionary<string, AtlasWeight> tileDataGrass { get; } = TransformWeightsToRange(new()
-    {
+    Dictionary<string, AtlasWeight> tileDataGrass { get; } = new()
+    {  
         { "grass_1", new AtlasWeight(new Vector2I(3, 1), 10f) },
         { "grass_2", new AtlasWeight(new Vector2I(0, 8), 10f) }
-    });
+    };
 
-    Dictionary<string, AtlasWeight> tileDataTrees { get; } = TransformWeightsToRange(new()
+    Dictionary<string, AtlasWeight> tileDataTrees { get; } = new()
     {
         { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 10f) }
-    });
+    };
 
     public override void _Ready()
     {
@@ -42,7 +42,7 @@ public partial class World : Node
         };
 
         Atlases.Add(new(Grass, grassNoise, tileDataGrass));
-        Atlases.Add(new(Trees, treeNoise, tileDataTrees));
+        Atlases.Add(new(Trees, treeNoise, tileDataTrees, 30f));
 
         GenerateSpawn();
     }
@@ -64,27 +64,6 @@ public partial class World : Node
         }
     }
 
-    public static Dictionary<string, AtlasWeight> TransformWeightsToRange(Dictionary<string, AtlasWeight> dictionary)
-    {
-        Dictionary<string, AtlasWeight> result = new();
-
-        float totalWeight = 0f;
-        foreach (var pair in dictionary) totalWeight += pair.Value.Weight;
     
-        // Set current value to the lowerbound of the range
-        float currentValue = -1;
-
-        // Transform the weights to be between [-1, 1], as per FastNoiseLite range
-        foreach (var pair in dictionary)
-        {
-            AtlasWeight atlasWeight = pair.Value;
-            float weight = atlasWeight.Weight;
-    
-            currentValue += weight / totalWeight * 2;
-    
-            result.Add(pair.Key, new AtlasWeight(atlasWeight.TilePosition, currentValue));
-        }
-        return result;
-    }
 
 }

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -3,10 +3,14 @@ namespace RTS;
 public partial class World : Node
 {
     public static World Instance { get; private set; }
-    public static Dictionary<string, AtlasWeight> Atlas { get; } = new()
+    public static Dictionary<string, AtlasWeight> AtlasGrass { get; } = new()
     {
         { "grass_1", new AtlasWeight(new Vector2I(3, 1), 0.3f) },
-        { "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) },
+        { "grass_2", new AtlasWeight(new Vector2I(0, 8), 1f) }
+    };
+
+    public static Dictionary<string, AtlasWeight> AtlasTrees { get; } = new()
+    {
         { "tree_1",  new AtlasWeight(new Vector2I(6, 4), 0.1f) }
     };
 

--- a/Scripts/RTS/World.cs
+++ b/Scripts/RTS/World.cs
@@ -55,24 +55,22 @@ public partial class World : Node
 
     public static Dictionary<string, AtlasWeight> TransformWeightsToRange(Dictionary<string, AtlasWeight> dictionary)
     {
-        
         Dictionary<string, AtlasWeight> result = new();
+
         float totalWeight = 0f;
-    
-        // Find the minimum and maximum weights in the dictionary
         foreach (var pair in dictionary) totalWeight += pair.Value.Weight;
     
+        // Set current value to the lowerbound of the range
         float currentValue = -1;
-        // Transform the weights to be between [-1, 1]
+
+        // Transform the weights to be between [-1, 1], as per FastNoiseLite range
         foreach (var pair in dictionary)
         {
             AtlasWeight atlasWeight = pair.Value;
             float weight = atlasWeight.Weight;
     
-            // Apply the transformation formula
             currentValue += weight / totalWeight * 2;
     
-            // Update the weight value in the AtlasWeight object
             result.Add(pair.Key, new AtlasWeight(atlasWeight.TilePosition, currentValue));
         }
         return result;


### PR DESCRIPTION
**Goal:**
Decouple the weight value system from the chunk class, this should belong in the World class

**Change:** 
- Added AtlasWeight
- Changed the dictionary in World to hold the weights per chunk type
- Modified Chunk to handle AtlasWeight and different tilemaps based on their name

**An issue to still fix =>**
Atlas Dictionary in "World.cs" now requires you to name the tile to the name of the tilemap, we should figure out a way to enforce this.

**Question:**
GD.PrintErr does not print to editor on my end